### PR TITLE
Removes Test as Decoder's parent

### DIFF
--- a/src/core/Decoder.sol
+++ b/src/core/Decoder.sol
@@ -49,7 +49,7 @@ import {Test} from "forge-std/Test.sol";
  *
  * note: there is currently no padding of the elements, so we are for now assuming nice trees as inputs.
  */
-contract Decoder is Test {
+contract Decoder {
     /**
      * @notice Decodes the inputs and computes values to check state against
      * @param _inputData - The inputs of the rollup block.


### PR DESCRIPTION
Removes the `Test` base contract from `Decoder`, since it's not a test file.

This was causing issues with `@aztec/ethereum.js`, since the base `Test` contract includes overloaded events and events with unnamed parameters, which are not supported by the `contract_gen_def` script.