### PR TITLE
Add a public rollupBlockNumber method

### DIFF
--- a/src/core/Rollup.sol
+++ b/src/core/Rollup.sol
@@ -20,6 +20,7 @@ contract Rollup is Decoder {
 
   MockVerifier public immutable VERIFIER;
   bytes32 public rollupStateHash;
+  uint256 public rollupBlockNumber;
 
   constructor() {
     VERIFIER = new MockVerifier();
@@ -47,6 +48,7 @@ contract Rollup is Decoder {
     }
 
     rollupStateHash = newStateHash;
+    rollupBlockNumber = l2BlockNumber;
 
     emit L2BlockProcessed(l2BlockNumber);
   }


### PR DESCRIPTION
Archiver depends on querying the latest block number to get the current state. While we could start searching for events backwards, a view method is the easiest way, and follows the philosophy of not giving a damn about gas costs.